### PR TITLE
Change homepage header punctuation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,7 +8,7 @@ export default function Home() {
       <section className="max-w-7xl mx-auto px-4 md:px-8 py-8 md:py-16">
         <div className="text-center mb-8 md:mb-12">
           <h1 className="font-serif text-4xl md:text-6xl lg:text-8xl font-semibold text-[#232323] leading-tight mb-6 md:mb-8">
-            Elevate your mind.
+            Elevate your mind!
           </h1>
         </div>
 


### PR DESCRIPTION
Change the homepage hero header from "Elevate your mind." to "Elevate your mind!".

---
<a href="https://cursor.com/background-agent?bcId=bc-f2750d9d-a846-43ee-b722-76de49cdd03d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f2750d9d-a846-43ee-b722-76de49cdd03d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

