### PR TITLE
Change homepage icon

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { Star, Quote } from "lucide-react";
+import { Star, Quote, MapPin } from "lucide-react";
 
 export default function Home() {
   return (
@@ -90,12 +90,7 @@ export default function Home() {
 
           <div className="text-center">
             <div className="w-16 h-16 rounded-full flex items-center justify-center mx-auto mb-6">
-              <Image
-                src={"/images/private-sessions.png"}
-                alt="Private Sessions"
-                width={64}
-                height={64}
-              />
+              <MapPin className="w-16 h-16 text-[#80978b]" strokeWidth={2.5} />
             </div>
             <h3 className="font-display text-lg md:text-xl font-bold text-[#656565] mb-3 md:mb-4">
               Conveniently


### PR DESCRIPTION
Replace the 'Conveniently Located' section's image icon with a `MapPin` icon from `lucide-react` as requested by the user.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9dc8cd3-8f10-4def-98f8-32c90da66781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d9dc8cd3-8f10-4def-98f8-32c90da66781">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

