### PR TITLE
Update banner text and button

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -450,10 +450,12 @@ export default function About() {
                   First-Time Trial at $19!​
                 </h2>
                 <p className="text-[17px] md:text-[19px] mb-6 md:mb-8">
-                  Discover the strength, balance, and grace of Reformer Pilates in a welcoming and empowering space. Join us at am Pilates and experience the difference.​
+                  Discover the strength, balance, and grace of Reformer Pilates in a welcoming and empowering space.
+                  <br />
+                  Join us at am Pilates and experience the difference.​
                 </p>
               </div>
-              <button className="cursor-pointer hover:bg-[lightgray] transition-all duration-300 bg-white text-[#80978b] px-6 md:px-8 py-3 rounded-full font-semibold">
+              <button className="cursor-pointer hover:bg-[lightgray] transition-all duration-300 bg-white text-[#80978b] px-8 md:px-12 py-3 rounded-full font-semibold whitespace-nowrap">
                 Get Trial Now
               </button>
             </div>

--- a/app/classes/page.tsx
+++ b/app/classes/page.tsx
@@ -240,11 +240,13 @@ export default function Classes() {
                   First-Time Trial at $19!​
                 </h2>
                 <p className="text-[17px] md:text-[19px] mb-6 md:mb-8">
-                  Discover the strength, balance, and grace of Reformer Pilates in a welcoming and empowering space. Join us at am Pilates and experience the difference.​
+                  Discover the strength, balance, and grace of Reformer Pilates in a welcoming and empowering space.
+                  <br />
+                  Join us at am Pilates and experience the difference.​
                 </p>
               </div>
               <Link href="/trial">
-                <button className="cursor-pointer hover:bg-[lightgray] transition-all duration-300 bg-white text-[#80978b] px-6 md:px-8 py-3 rounded-full font-semibold">
+                <button className="cursor-pointer hover:bg-[lightgray] transition-all duration-300 bg-white text-[#80978b] px-8 md:px-12 py-3 rounded-full font-semibold whitespace-nowrap">
                   Get Trial Now
                 </button>
               </Link>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,10 +122,12 @@ export default function Home() {
                   First-Time Trial at $19!​
                 </h2>
                 <p className="text-[17px] md:text-[19px] mb-6 md:mb-8">
-                  Discover the strength, balance, and grace of Reformer Pilates in a welcoming and empowering space. Join us at am Pilates and experience the difference.​
+                  Discover the strength, balance, and grace of Reformer Pilates in a welcoming and empowering space.
+                  <br />
+                  Join us at am Pilates and experience the difference.​
                 </p>
               </div>
-              <button className="cursor-pointer hover:bg-[lightgray] transition-all duration-300 bg-white text-[#80978b] px-6 md:px-8 py-3 rounded-full font-semibold">
+              <button className="cursor-pointer hover:bg-[lightgray] transition-all duration-300 bg-white text-[#80978b] px-8 md:px-12 py-3 rounded-full font-semibold whitespace-nowrap">
                 Get Trial Now
               </button>
             </div>
@@ -224,7 +226,7 @@ export default function Home() {
 
         <div className="text-center mt-8">
           <button
-            className="bg-[#80978b] hover:bg-[#6b8276] cursor-pointer text-white px-8 py-3 rounded-full font-semibold transition-colors duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#80978b] focus:ring-offset-2"
+            className="bg-[#80978b] hover:bg-[#6b8276] cursor-pointer text-white px-10 md:px-12 py-3 rounded-full font-semibold transition-colors duration-200 shadow-sm hover:shadow-md focus:outline-none focus:ring-2 focus:ring-[#80978b] focus:ring-offset-2 whitespace-nowrap"
             aria-label="Start your free trial"
           >
             Get Trial Now


### PR DESCRIPTION
Add line break to trial banner text and make 'Get Trial Now' buttons single-line and wider for improved readability and appearance.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8debcd1-c384-4e46-9683-ab7768c3d2de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8debcd1-c384-4e46-9683-ab7768c3d2de">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

