### PR TITLE
Adjust homepage introductory class sentence display

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -139,8 +139,8 @@ export default function Home() {
         <h2 className="font-serif text-3xl md:text-4xl lg:text-5xl font-bold text-[#80978b] mb-6 md:mb-8">
           Our Classes
         </h2>
-        <p className="text-base md:text-lg text-[#656565] mb-4 max-w-2xl">
-          New to am Pilates? Your journey beginswith a fun and friendly Introductory Class—just one session to get you comfortable and confident before joining our regular classes!​
+        <p className="text-lg md:text-xl text-[#656565] leading-snug mb-4 w-full">
+          New to am Pilates? Your journey begins with a fun and friendly Introductory Class—just one session to get you comfortable and confident before joining our regular classes!​
         </p>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 md:gap-8 mt-8 md:mt-12">


### PR DESCRIPTION
Adjust homepage introductory text styling to span full width and fit one or two lines, while also correcting a typo.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea973c96-38a1-466f-8e97-5b253816869b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea973c96-38a1-466f-8e97-5b253816869b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

