### PR TITLE
Align dropdown arrow in contact form

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,5 +1,5 @@
 import Image from "next/image";
-import { Mail, Phone } from "lucide-react";
+import { Mail, Phone, ChevronDown } from "lucide-react";
 
 export default function Contact() {
   return (
@@ -75,10 +75,13 @@ export default function Contact() {
             />
             <div>
               <label className="block text-[#656565] text-sm md:text-base mb-2">Location</label>
-              <select className="w-full p-3 md:p-4 rounded-full bg-white border border-gray-300 focus:outline-none focus:border-[#80978b] text-sm md:text-base">
-                <option>Jurong CPF</option>
-                <option>Punggol Coast Mall</option>
-              </select>
+              <div className="relative">
+                <select className="w-full p-3 md:p-4 pr-10 rounded-full bg-white border border-gray-300 focus:outline-none focus:border-[#80978b] text-sm md:text-base appearance-none">
+                  <option>Jurong CPF</option>
+                  <option>Punggol Coast Mall</option>
+                </select>
+                <ChevronDown className="pointer-events-none absolute right-4 md:right-5 top-1/2 -translate-y-1/2 h-4 w-4 text-[#656565]" />
+              </div>
             </div>
             <textarea
               placeholder="Your message"


### PR DESCRIPTION
Fix dropdown arrow alignment in the 'Location' field of the contact form by replacing the native arrow with a custom icon.

---
<a href="https://cursor.com/background-agent?bcId=bc-cf2374e3-e3fe-48a2-b54b-2040d2fb8504">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cf2374e3-e3fe-48a2-b54b-2040d2fb8504">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

