### PR TITLE
Rename class titles on pages

### DIFF
--- a/app/classes/page.tsx
+++ b/app/classes/page.tsx
@@ -58,7 +58,7 @@ export default function Classes() {
         "Never Tried Reformer Pilates before? This Introductory Class is the perfect first step. You'll get to know the equipment, learn key safety tips, and understand the terms and cues used in class. Plus, we'll guide you through body alignment basics to help you move with confidence and ease.",
     },
     {
-      title: "Essential Strength",
+      title: "Firm Foundation",
       imageSrc: "/images/our-class-2.png",
       imageAlt: "Essential Strength",
       difficulty: 2,

--- a/app/components/ClassesCarousel.tsx
+++ b/app/components/ClassesCarousel.tsx
@@ -31,7 +31,7 @@ const ClassesCarousel = ({ heading, intro }: ClassesCarouselProps) => {
           "Never Tried Reformer Pilates before? This Introductory Class is the perfect first step. You'll get to know the equipment, learn key safety tips, and understand the terms and cues used in class. Plus, we'll guide you through body alignment basics to help you move with confidence and ease.",
       },
       {
-        title: "Essential Strength",
+        title: "Firm Foundation",
         imageSrc: "/images/essential-strength-1.png",
         imageAlt: "Essential Strength",
         difficulty: 2,


### PR DESCRIPTION
Rename "Essential Strength" class title to "Firm Foundation" on the homepage and classes page.

---
<a href="https://cursor.com/background-agent?bcId=bc-4ab5a4e7-5cc7-4fde-a651-ef74cf708957">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4ab5a4e7-5cc7-4fde-a651-ef74cf708957">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

