### PR TITLE
Fix cookie modification error on admin pages

### DIFF
--- a/lib/supabase-middleware.ts
+++ b/lib/supabase-middleware.ts
@@ -1,0 +1,32 @@
+import { createServerClient as createSupabaseServerClient } from "@supabase/ssr";
+import { type NextRequest, NextResponse } from "next/server";
+
+export const createMiddlewareClient = (request: NextRequest) => {
+  let supabaseResponse = NextResponse.next({ request });
+
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || "";
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || "";
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Missing Supabase environment variables");
+  }
+
+  const supabase = createSupabaseServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return request.cookies.getAll();
+      },
+      setAll(cookiesToSet) {
+        cookiesToSet.forEach(({ name, value }) => {
+          request.cookies.set(name, value);
+        });
+        supabaseResponse = NextResponse.next({ request });
+        cookiesToSet.forEach(({ name, value, options }) => {
+          supabaseResponse.cookies.set(name, value, options);
+        });
+      },
+    },
+  });
+
+  return { supabase, supabaseResponse };
+};

--- a/lib/supabase-server.ts
+++ b/lib/supabase-server.ts
@@ -17,9 +17,14 @@ export const createServerClient = async () => {
         return cookieStore.getAll();
       },
       setAll(cookiesToSet) {
-        cookiesToSet.forEach(({ name, value, options }) => {
-          cookieStore.set(name, value, options);
-        });
+        try {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            cookieStore.set(name, value, options);
+          });
+        } catch {
+          // Called from a Server Component where cookies are read-only.
+          // Session refresh is handled in middleware instead.
+        }
       },
     },
   });

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,15 @@
+import { type NextRequest } from "next/server";
+
+import { createMiddlewareClient } from "@/lib/supabase-middleware";
+
+export async function middleware(request: NextRequest) {
+  const { supabase, supabaseResponse } = createMiddlewareClient(request);
+
+  await supabase.auth.getUser();
+
+  return supabaseResponse;
+}
+
+export const config = {
+  matcher: ["/admin/:path*", "/api/upload"],
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Visiting `/admin/team` (and other admin pages) caused a fatal server crash:

```
Error: Cookies can only be modified in a Server Action or Route Handler.
```

This happened because `getCurrentAdmin()` calls Supabase's `auth.getUser()`, which may refresh the session and attempt to write cookies via `setAll` during Server Component rendering — a context where Next.js only allows read access to cookies.

## Solution

1. **Middleware session refresh** — Added `middleware.ts` that refreshes the Supabase auth session on `/admin/*` and `/api/upload` routes, where cookies can be written.
2. **Safe cookie writes in server client** — Wrapped `setAll` in `lib/supabase-server.ts` with a try/catch so Server Component renders don't crash if a session refresh is attempted outside middleware.

This follows the [Supabase Next.js SSR guidance](https://supabase.com/docs/guides/auth/server-side/nextjs) for handling cookie updates across middleware, Server Components, and Server Actions.

## Files changed

- `middleware.ts` — new middleware for auth session refresh
- `lib/supabase-middleware.ts` — Supabase client configured for middleware cookie handling
- `lib/supabase-server.ts` — safe `setAll` with try/catch for Server Component contexts
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f3ba0-769e-7c52-9cb4-167aa2588c72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f3ba0-769e-7c52-9cb4-167aa2588c72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

